### PR TITLE
Explicitly disable harfbuzz for freetype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(SFML-dependencies)
 
-# Easy ones with cmake support first
+# Disable harfbuzz for freetype
+set(WITH_HarfBuzz FALSE)
 add_subdirectory(freetype2)
+
+# No extra configuration for ogg
 add_subdirectory(ogg)
 
 # openal-soft is provided by emscripten so we don't need to build


### PR DESCRIPTION
By pure chance ended up with versions of harfbuzz and ICU on my machine which didn't match up with what freetype expects.

Hasn't previously been an issue because if harfbuzz isn't found freetype just continues silently without it.

Given we don't use harfbuzz anyway, we should explicitly disable it so the build dependencies are consistent