### PR TITLE
Update openal-soft from 1.21.0 to 1.21.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "openal-soft"]
 	path = openal-soft
 	url = https://github.com/kcat/openal-soft.git
-	branch = openal-soft-1.21.0
+	branch = openal-soft-1.21.1
 [submodule "stb"]
 	path = stb
 	url = https://github.com/nothings/stb.git

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 | [opus](https://xiph.org/flac/)                         | v1.3.1             | `https://github.com/xiph/opus.git`                     |
 | [opusfile](https://github.com/xiph/opusfile)           | v0.12              | `https://github.com/xiph/opusfile.git`                 |
 | [freetype2](https://www.freetype.org/)                 | VER-2-12-1         | `https://gitlab.freedesktop.org/freetype/freetype.git` | 
-| [openal-soft](http://kcat.strangesoft.net/openal.html) | openal-soft-1.21.0 | `https://github.com/kcat/openal-soft.git`              |
+| [openal-soft](http://kcat.strangesoft.net/openal.html) | openal-soft-1.21.1 | `https://github.com/kcat/openal-soft.git`              |
 | [stb_*](https://github.com/nothings/stb)               | master             | `https://github.com/nothings/stb.git`                  |
 
 ## Building


### PR DESCRIPTION
This version of OpenAl fixes some ARM and ARM64 bugs.

Also, I got SFML 2 to work flawlessly on Windows ARM64 with this fix. 😊