### PR TITLE
Fix issue with openal32 dll requiring vc_redist on ARM64 Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,12 @@ if (NOT EMSCRIPTEN AND NOT IOS)
     set(ALSOFT_EXAMPLES OFF CACHE BOOL "")
     set(ALSOFT_TESTS OFF CACHE BOOL "")
     set(CMAKE_DISABLE_FIND_PACKAGE_WindowsSDK ON CACHE BOOL "")
-    # Ensure the redistributables are compiled in for openal
-    set(FORCE_STATIC_VCRT ON)
 
     message(STATUS "Configuring openal-soft")
+    # Ensure the redistributables are compiled in for openal
+    if(MSVC)
+        set(FORCE_STATIC_VCRT ON)
+    endif()
     add_subdirectory(openal-soft)
 
     # Ensure -fcommon is used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ if (NOT EMSCRIPTEN AND NOT IOS)
     set(ALSOFT_EXAMPLES OFF CACHE BOOL "")
     set(ALSOFT_TESTS OFF CACHE BOOL "")
     set(CMAKE_DISABLE_FIND_PACKAGE_WindowsSDK ON CACHE BOOL "")
+    # Ensure the redistributables are compiled in for openal
+    set(FORCE_STATIC_VCRT ON)
 
     message(STATUS "Configuring openal-soft")
     add_subdirectory(openal-soft)


### PR DESCRIPTION
As title says.
The opeanal32 dll for x86 and x64 does not require the vc_redistributables, however the ARM64 currently does.
This PR fixes it, making it so all of them do not require the vc_redistributables.